### PR TITLE
Simplify MCP tool calling with Microsoft.Extensions.AI (replace Semantic Kernel)

### DIFF
--- a/MCP-ToolCalling/README.md
+++ b/MCP-ToolCalling/README.md
@@ -1,6 +1,6 @@
 # Foundry Local MCP Integration
 
-An example demonstrating how to integrate MCP servers with Foundry Local and Semantic Kernel using tool calling. A custom Weather MCP server exposes real-time weather data, and a .NET agent uses Semantic Kernel to connect Foundry Local's locally-running model to those tools.
+An example demonstrating how to integrate MCP servers with Foundry Local using tool calling. A custom Weather MCP server exposes real-time weather data, and a .NET agent uses **Microsoft.Extensions.AI** over Foundry Local's OpenAI-compatible endpoint to connect the locally-running model to those tools. The MCP tools auto-wire as `AIFunction`s and are invoked automatically — no Semantic Kernel and no manual tool loop required.
 
 ## Architecture
 
@@ -9,9 +9,9 @@ An example demonstrating how to integrate MCP servers with Foundry Local and Sem
 │              foundry-local-mcp-agent (.NET)          │
 │                                                      │
 │  ┌─────────────────┐      ┌────────────────────────┐ │
-│  │  Foundry Local  │      │   Semantic Kernel       │ │
-│  │  (qwen2.5-7b)   │◄────►│   + WeatherMcpPlugin   │ │
-│  │  port 9001      │      │                        │ │
+│  │  Foundry Local  │      │  Microsoft.Extensions.AI│ │
+│  │  (qwen2.5-7b)   │◄────►│  function-invoking      │ │
+│  │  port 9001      │      │  IChatClient + MCP tools│ │
 │  └─────────────────┘      └──────────┬─────────────┘ │
 └─────────────────────────────────────┼───────────────┘
                                        │ MCP over HTTP
@@ -62,23 +62,24 @@ The server starts on `http://localhost:3000`. You can verify it is running by na
 
 The agent is a .NET 9 console application that:
 
-1. Starts an embedded **Foundry Local** instance and downloads/loads the `qwen2.5-7b` model
-2. Connects to the Weather MCP Server via `McpHttpClient`
-3. Registers a **Semantic Kernel** plugin (`WeatherMcpPlugin`) that wraps the MCP tools
-4. Runs an interactive chat loop where the model automatically invokes weather tools as needed
+1. Starts an embedded **Foundry Local** instance, loads the `qwen2.5-7b` model, and starts its OpenAI-compatible web service
+2. Connects to the Weather MCP Server using the `ModelContextProtocol` HTTP transport
+3. Builds a function-invoking `IChatClient` (Microsoft.Extensions.AI) over the Foundry Local endpoint and passes the MCP tools (which are `AIFunction`s) directly to it
+4. Runs an interactive chat loop — `UseFunctionInvocation()` automatically executes any requested MCP tools and feeds the results back to the model
 
 Open a second terminal and run:
 
 ```bash
 cd foundry-local-mcp-agent
-dotnet run
+dotnet run                 # defaults to qwen2.5-7b
+dotnet run -- qwen2.5-7b   # or pass a model alias explicitly
 ```
 
 On first run, the model will be downloaded. Subsequent runs reuse the cached model.
 
 ## Usage
 
-Once running, type natural language weather questions at the `>` prompt. The model uses Semantic Kernel's automatic tool invocation (`FunctionChoiceBehavior.Auto()`) to decide which MCP tool to call.
+Once running, type natural language weather questions at the `>` prompt. The model decides which MCP tool to call; `Microsoft.Extensions.AI` executes it via the MCP client automatically and returns the result to the model for a final, grounded answer.
 
 **Example queries:**
 
@@ -89,7 +90,7 @@ Once running, type natural language weather questions at the `>` prompt. The mod
 > Give me the forecast for New York City.
 ```
 
-Type `exit` to quit. The agent will stop the Foundry Local web service and unload the model on exit.
+Type `exit` to quit. The agent disconnects from the MCP server, stops the web service, and unloads the model on exit.
 
 ## Project Structure
 
@@ -101,10 +102,7 @@ MCP-ToolCalling/
 │       ├── package.json
 │       └── tsconfig.json
 └── foundry-local-mcp-agent/
-    ├── Program.cs              # Entry point: Foundry Local setup + chat loop
-    ├── McpHttpClient.cs        # MCP Streamable HTTP client (initialize/list tools/call tool)
-    ├── WeatherMcpPlugin.cs     # Semantic Kernel plugin wrapping MCP tools
-    ├── Utils.cs                # Helper utilities (spinner, logging)
+    ├── Program.cs              # Foundry Local setup, MCP client, function-invoking chat loop
     └── foundry-local-mcp-agent.csproj
 ```
 
@@ -113,13 +111,16 @@ MCP-ToolCalling/
 | Component | Package |
 |---|---|
 | Local model hosting | `Microsoft.AI.Foundry.Local.WinML` |
-| AI orchestration | `Microsoft.SemanticKernel` |
-| OpenAI-compatible client | `Microsoft.SemanticKernel.Connectors.OpenAI` |
-| MCP transport | Custom `McpHttpClient` over HTTP |
+| Chat client + automatic tool invocation | `Microsoft.Extensions.AI`, `Microsoft.Extensions.AI.OpenAI`, `OpenAI` |
+| MCP client + HTTP transport | `ModelContextProtocol` |
 | Weather data | US National Weather Service API (no API key required) |
 
 ## Troubleshooting
 
 **`Error connecting to MCP server`** — Make sure the Weather MCP Server is running before starting the agent. Run `npm run start` from `mcp-servers/weather` first.
+
+**Tools are never called / the model prints `<tool_call>` as text** — Use a non-thinking **instruct** model (e.g. `qwen2.5-7b`). Foundry Local's server-side parser cannot extract tool calls from reasoning models like Qwen3 that emit a `<think>` block before the call. The agent uses non-streaming completions, which is required because Foundry Local only populates structured `tool_calls` on non-streaming responses.
+
+**`Failed to allocate memory` / ONNX BFC arena error on multi-GPU machines** — The CUDA execution provider may bind to a GPU too small to hold the model. Pin the process to a larger GPU by setting `CUDA_VISIBLE_DEVICES` (the sample defaults it to `0`).
 
 **Weather data only covers the US** — The NWS API only covers US locations. State alert codes must be two-letter US state abbreviations (e.g. `CA`, `NY`, `TX`). Forecast coordinates outside the US will return an error from the NWS API.

--- a/MCP-ToolCalling/README.md
+++ b/MCP-ToolCalling/README.md
@@ -56,7 +56,7 @@ The server starts on `http://localhost:3000`. You can verify it is running by na
 > ```bash
 > PORT=4000 npm run start
 > ```
-> Then update the `McpHttpClient` initialization in [Program.cs](foundry-local-mcp-agent/Program.cs) to match.
+> Then update the MCP endpoint URI in [Program.cs](foundry-local-mcp-agent/Program.cs) to match — see the `HttpClientTransport` `Endpoint` (`http://localhost:3000/mcp`).
 
 ## Step 2: Run the Foundry Local MCP Agent
 
@@ -121,6 +121,6 @@ MCP-ToolCalling/
 
 **Tools are never called / the model prints `<tool_call>` as text** — Use a non-thinking **instruct** model (e.g. `qwen2.5-7b`). Foundry Local's server-side parser cannot extract tool calls from reasoning models like Qwen3 that emit a `<think>` block before the call. The agent uses non-streaming completions, which is required because Foundry Local only populates structured `tool_calls` on non-streaming responses.
 
-**`Failed to allocate memory` / ONNX BFC arena error on multi-GPU machines** — The CUDA execution provider may bind to a GPU too small to hold the model. Pin the process to a larger GPU by setting `CUDA_VISIBLE_DEVICES` (the sample defaults it to `0`).
+**`Failed to allocate memory` / ONNX BFC arena error on multi-GPU machines** — The CUDA execution provider may bind to a GPU too small to hold the model. CUDA targets GPU `0` by default when `CUDA_VISIBLE_DEVICES` is unset; if that GPU is too small, pin the process to a larger one by setting the variable yourself before running, e.g. `CUDA_VISIBLE_DEVICES=1 dotnet run`.
 
 **Weather data only covers the US** — The NWS API only covers US locations. State alert codes must be two-letter US state abbreviations (e.g. `CA`, `NY`, `TX`). Forecast coordinates outside the US will return an error from the NWS API.

--- a/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
@@ -1,12 +1,13 @@
-﻿using Microsoft.AI.Foundry.Local;
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.ChatCompletion;
-using Microsoft.SemanticKernel.Connectors.OpenAI;
 using ModelContextProtocol.Client;
+using OpenAI;
+using System.ClientModel;
 
 
-var alias = "qwen2.5-7b";
+var alias = args.Length > 0 ? args[0] : "qwen2.5-7b";
+var ct = CancellationToken.None;
 var foundryLocalWebUrl = "http://127.0.0.1:9001";
 
 
@@ -85,8 +86,8 @@ Console.Write($"Loading model {model.Id}...");
 await model.LoadAsync();
 Console.WriteLine("done.");
 
-// Start the web service
-Console.Write($"Starting web service on {config.Web.Urls}...");
+// Start the OpenAI-compatible web service
+Console.Write($"Starting web service on {foundryLocalWebUrl}...");
 await mgr.StartWebServiceAsync();
 Console.WriteLine("done.");
 
@@ -112,20 +113,29 @@ foreach (var tool in tools)
 Console.WriteLine();
 
 
-// Step 3: Create Semantic Kernel with OpenAI-compatible endpoint and add Weather MCP Plugin
-var builder = Kernel.CreateBuilder().AddOpenAIChatCompletion(
-    modelId: model.Id,
-    endpoint: new Uri(foundryLocalWebUrl + "/v1"),
-    apiKey: "not needed");
+// Step 3: Build a function-invoking chat client over Foundry Local's OpenAI-compatible endpoint.
+// MCP tools are already AIFunctions, so they plug in directly and are invoked automatically by UseFunctionInvocation().
+// Non-streaming GetResponseAsync is used because Foundry Local only populates structured tool calls on non-streaming responses.
+var openAIClient = new OpenAIClient(
+    new ApiKeyCredential("not-needed"),
+    new OpenAIClientOptions { Endpoint = new Uri($"{foundryLocalWebUrl}/v1") });
 
-builder.Plugins.AddFromFunctions("WeatherMCP", tools.Select(t => t.AsKernelFunction()));
+IChatClient chatClient = openAIClient
+    .GetChatClient(model.Id)
+    .AsIChatClient()
+    .AsBuilder()
+    .UseFunctionInvocation()
+    .Build();
 
-var kernel = builder.Build();
+var options = new ChatOptions
+{
+    Tools = [.. tools],
+    Temperature = 0.1f
+};
 
-
-// Step 4: Create chat history and get chat service
-var history = new ChatHistory();
-history.AddSystemMessage(@"You are a helpful weather assistant. You have access to weather tools that can:
+var messages = new List<ChatMessage>
+{
+    new(ChatRole.System, @"You are a helpful weather assistant. You have access to weather tools that can:
 1. Get weather alerts for US states (use two-letter state codes like CA, NY, TX)
 2. Get weather forecasts for locations using latitude and longitude coordinates
 
@@ -135,12 +145,11 @@ Some common coordinates:
 - New York: 40.7128, -74.0060
 - Los Angeles: 34.0522, -118.2437
 - Chicago: 41.8781, -87.6298
-- Miami: 25.7617, -80.1918");
+- Miami: 25.7617, -80.1918")
+};
 
-var chatService = kernel.GetRequiredService<IChatCompletionService>();
 
-
-// Step 5: Interactive chat loop
+// Step 4: Interactive chat loop
 Console.WriteLine("Chat with the Weather Assistant (type 'exit' to quit)");
 Console.WriteLine("Try asking questions like:");
 Console.WriteLine("  - What are the weather alerts in California?");
@@ -161,26 +170,16 @@ while (prompt.CompareTo("exit") != 0)
     if (string.IsNullOrWhiteSpace(prompt))
         continue;
 
-    history.AddUserMessage(prompt);
+    messages.Add(new(ChatRole.User, prompt));
 
     try
     {
-        var executionSettings = new OpenAIPromptExecutionSettings()
-        {
-            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
-            Temperature = 0.1
-        };
-
-        // Foundry Local only populates structured tool_calls on non-streaming responses
-        // (streaming chunks always return tool_calls: []), so use the non-streaming API
-        // to let Semantic Kernel automatically invoke the MCP tools.
-        var response = await chatService.GetChatMessageContentAsync(
-            history,
-            executionSettings: executionSettings,
-            kernel: kernel);
-
-        Console.WriteLine(response.Content + "\n");
-        history.Add(response);
+        // The function-invoking client handles the full tool loop: it calls the model,
+        // executes any requested MCP tools, feeds the results back, and returns the
+        // final grounded answer.
+        var response = await chatClient.GetResponseAsync(messages, options, ct);
+        Console.WriteLine(response.Text + "\n");
+        messages.AddMessages(response);
     }
     catch (Exception ex)
     {
@@ -189,8 +188,7 @@ while (prompt.CompareTo("exit") != 0)
 }
 
 
-// Tidy up
-// Stop the web service and unload model
+// Tidy up - disconnect MCP, stop the web service, and unload the model
 Console.WriteLine("Goodbye!");
 await mcpClient.DisposeAsync();
 await mgr.StopWebServiceAsync();

--- a/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
@@ -178,7 +178,12 @@ while (prompt.CompareTo("exit") != 0)
         // executes any requested MCP tools, feeds the results back, and returns the
         // final grounded answer.
         var response = await chatClient.GetResponseAsync(messages, options, ct);
-        Console.WriteLine(response.Text + "\n");
+
+        // Print only the final assistant message. response.Text concatenates every
+        // assistant turn, which would also include the intermediate tool-calling turn
+        // (some models, e.g. Qwen, echo the <tool_call> JSON as content there).
+        var answer = response.Messages.LastOrDefault(m => m.Role == ChatRole.Assistant)?.Text;
+        Console.WriteLine((string.IsNullOrWhiteSpace(answer) ? response.Text : answer) + "\n");
         messages.AddMessages(response);
     }
     catch (Exception ex)

--- a/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using ModelContextProtocol.Client;
-using System.Text;
 
 
 var alias = "qwen2.5-7b";
@@ -163,7 +162,6 @@ while (prompt.CompareTo("exit") != 0)
         continue;
 
     history.AddUserMessage(prompt);
-    StringBuilder fullResponse = new StringBuilder();
 
     try
     {
@@ -173,19 +171,16 @@ while (prompt.CompareTo("exit") != 0)
             Temperature = 0.1
         };
 
-        // Stream the response with automatic tool invocation
-        await foreach (var response in chatService.GetStreamingChatMessageContentsAsync(
+        // Foundry Local only populates structured tool_calls on non-streaming responses
+        // (streaming chunks always return tool_calls: []), so use the non-streaming API
+        // to let Semantic Kernel automatically invoke the MCP tools.
+        var response = await chatService.GetChatMessageContentAsync(
             history,
             executionSettings: executionSettings,
-            kernel: kernel
-        ))
-        {
-            fullResponse.Append(response.Content);
-            Console.Write(response.Content);
-        }
+            kernel: kernel);
 
-        Console.WriteLine("\n");
-        history.AddAssistantMessage(fullResponse.ToString());
+        Console.WriteLine(response.Content + "\n");
+        history.Add(response);
     }
     catch (Exception ex)
     {

--- a/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/Program.cs
@@ -6,7 +6,7 @@ using OpenAI;
 using System.ClientModel;
 
 
-var alias = args.Length > 0 ? args[0] : "qwen2.5-7b";
+var alias = args.FirstOrDefault(a => !string.IsNullOrWhiteSpace(a))?.Trim() ?? "qwen2.5-7b";
 var ct = CancellationToken.None;
 var foundryLocalWebUrl = "http://127.0.0.1:9001";
 

--- a/MCP-ToolCalling/foundry-local-mcp-agent/foundry-local-mcp-agent.csproj
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/foundry-local-mcp-agent.csproj
@@ -41,15 +41,11 @@
 		</ItemGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
-				<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+				<PackageReference Include="Microsoft.Extensions.AI" Version="10.4.1" />
+				<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
 				<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-				<PackageReference Include="Microsoft.SemanticKernel" Version="1.77.0" />
-				<PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.77.0" />
-				<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.77.0" />
 				<PackageReference Include="ModelContextProtocol" Version="1.4.0" />
 				<PackageReference Include="OpenAI" Version="2.11.0" />
-				<PackageReference Include="System.Memory.Data" Version="10.0.9" />
 		</ItemGroup>
 
 </Project>

--- a/MCP-ToolCalling/foundry-local-mcp-agent/foundry-local-mcp-agent.csproj
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/foundry-local-mcp-agent.csproj
@@ -41,8 +41,8 @@
 		</ItemGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Microsoft.Extensions.AI" Version="10.4.1" />
-				<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
+				<PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+				<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
 				<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
 				<PackageReference Include="ModelContextProtocol" Version="1.4.0" />
 				<PackageReference Include="OpenAI" Version="2.11.0" />

--- a/MCP-ToolCalling/foundry-local-mcp-agent/foundry-local-mcp-agent.csproj
+++ b/MCP-ToolCalling/foundry-local-mcp-agent/foundry-local-mcp-agent.csproj
@@ -26,7 +26,7 @@
 
 		<!-- Windows: WinML for hardware acceleration -->
 		<ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-				<PackageReference Include="Microsoft.AI.Foundry.Local.WinML" Version="1.0.0" />
+				<PackageReference Include="Microsoft.AI.Foundry.Local.WinML" Version="1.2.3" />
 		</ItemGroup>
 
 		<!-- Non-Windows: standard SDK -->
@@ -41,15 +41,15 @@
 		</ItemGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Microsoft.Extensions.AI" Version="10.5.0" />
-				<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.0" />
-				<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-				<PackageReference Include="Microsoft.SemanticKernel" Version="1.74.0" />
-				<PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.74.0" />
-				<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.74.0" />
-				<PackageReference Include="ModelContextProtocol" Version="1.2.0" />
-				<PackageReference Include="OpenAI" Version="2.10.0" />
-				<PackageReference Include="System.Memory.Data" Version="10.0.7" />
+				<PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+				<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+				<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+				<PackageReference Include="Microsoft.SemanticKernel" Version="1.77.0" />
+				<PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.77.0" />
+				<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.77.0" />
+				<PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+				<PackageReference Include="OpenAI" Version="2.11.0" />
+				<PackageReference Include="System.Memory.Data" Version="10.0.9" />
 		</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Simplifies the **MCP-ToolCalling** sample by replacing the Semantic Kernel tool loop with **Microsoft.Extensions.AI** function invocation against Foundry Local''s OpenAI-compatible endpoint. MCP tools are already `AIFunction`s, so they plug directly into the chat client and are invoked automatically — collapsing the tool-calling code from ~120 lines to ~10, with no Semantic Kernel dependency.

## Changes

- **Program.cs** — Replace the SK kernel/plugin/`FunctionChoiceBehavior` loop with a function-invoking `IChatClient`:
  `OpenAIClient(Endpoint = FL /v1).GetChatClient(id).AsIChatClient().AsBuilder().UseFunctionInvocation().Build()`, passing the MCP tools via `ChatOptions.Tools`. Removes the manual schema mapping, argument parsing, and tool-dispatch loop. Model alias is now an optional CLI arg (defaults to `qwen2.5-7b`).
- **foundry-local-mcp-agent.csproj** — Drop the `Microsoft.SemanticKernel*` packages; add `Microsoft.Extensions.AI`, `Microsoft.Extensions.AI.OpenAI`, and `OpenAI`.
- **README.md** — Update architecture diagram, usage flow, dependencies, and troubleshooting.

## Notes / gotchas

- **Non-streaming is required.** Foundry Local only populates structured `tool_calls` on non-streaming responses; streaming chunks return the call as raw `<tool_call>` text with an empty `tool_calls` array.
- **Use a non-thinking instruct model** (e.g. `qwen2.5-7b`). Foundry Local''s server-side parser cannot extract tool calls from reasoning models like Qwen3 that emit a `<think>` block before the call.

## Testing

- `dotnet build` succeeds.
- Verified end-to-end against the Weather MCP server: `get_alerts` (CA) and `get_forecast` (Seattle) are invoked automatically and return live NWS data.